### PR TITLE
Keep app height stable on mobile

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -49,7 +49,10 @@ export default function RootLayout({
           storageKey="theme"
           defaultTheme="system"
         >
-          <div className="flex min-h-screen w-full flex-col font-[family-name:var(--font-inter-tight)]">
+          <div
+            className="flex min-h-screen w-full flex-col font-[family-name:var(--font-inter-tight)]"
+            style={{ minHeight: '100svh' }}
+          >
             <div className="relative mx-auto w-full max-w-screen-sm flex-1 px-4 pt-20">
               <Header />
               {children}


### PR DESCRIPTION
## Summary
- ensure the global layout honors a stable viewport height using the `100svh` unit so that focusing the prompt input on mobile no longer causes the entire page to resize

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919657c2ff4832996644312a98a0bd5)