### PR TITLE
Fix: Correctly spread inputs in cn function

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,7 +2,7 @@ import { ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(...inputs))
 }
 
 export const readFileAsDataURL = (file: File) =>


### PR DESCRIPTION
The `cn` utility function was incorrectly passing the `inputs` array as a single argument to `clsx`, causing issues with class merging. This commit spreads the array to pass each class value as a separate argument, as intended by the `clsx` library.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes `cn` by spreading `inputs` into `clsx` to ensure proper Tailwind class merging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 600c48de0cc6917a0b543b456b593321faf4cdd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->