### PR TITLE
Switch agent model to Claude Opus 4.5

### DIFF
--- a/src/lib/agent/runner.ts
+++ b/src/lib/agent/runner.ts
@@ -292,7 +292,7 @@ export async function runAgent({
       // Model selection
       // Note: Effort parameter is ONLY supported by Claude Opus 4.5
       // @see https://platform.claude.com/docs/en/build-with-claude/effort
-      const MODEL = 'claude-haiku-4-5-20251001'
+      const MODEL = 'claude-opus-4-5-20251101'
       const isOpusModel = MODEL.includes('opus')
 
       // Build beta headers list


### PR DESCRIPTION
## Summary
- update the agent runner to use Claude Opus 4.5 as the model

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d252aff0083299d1747adc1998672)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update agent runner to use `claude-opus-4-5-20251101` instead of `claude-haiku-4-5-20251001`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 844958e334950a30a3880d00323295cec64787c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->